### PR TITLE
Detect os

### DIFF
--- a/rleb_settings.py
+++ b/rleb_settings.py
@@ -24,7 +24,15 @@ queues = {}
 
 # OS (Either windows or linux)
 # TODO: Automatically get the running environment
-RUNNING_ENVIRONMENT = platform 
+ENVIRONMENT_DICT = {
+        'aix': 'aix',
+        'linux': 'linux',
+        'win32': 'windows',
+        'cygwin': 'cygwin',
+        'darwin': 'mac'
+}
+
+RUNNING_ENVIRONMENT = ENVIRONMENT_DICT[platform]
 
 RUNNING_MODE = os.environ.get('RUNNING_MODE') or secrets.RUNNING_MODE
 


### PR DESCRIPTION
Detects the appropriate OS. Uses a dictionary to map the built in python strings to more readable strings, i.e., "darwin" -> "mac" and "win32" -> "windows".  